### PR TITLE
feat: [ENG-391] Add SwaggerPathsToGorillaPaths in chi request validator

### DIFF
--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -46,11 +46,12 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 		log.Println("WARN: OapiRequestValidatorWithOptions called with an OpenAPI spec that has `Servers` set. This may lead to an HTTP 400 with `no matching operation was found` when sending a valid request, as the validator performs `Host` header validation. If you're expecting `Host` header validation, you can silence this warning by setting `Options.SilenceServersWarning = true`. See https://github.com/clinia/oapi-codegen/issues/882 for more information.")
 	}
 
+	swagger.Paths = SwaggerPathsToGorillaPaths(swagger.Paths)
+
 	router, err := gorillamux.NewRouter(swagger)
 	if err != nil {
 		panic(err)
 	}
-	swagger.Paths = SwaggerPathsToGorillaPaths(swagger.Paths)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/clinia/oapi-codegen/pkg/codegen"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/getkin/kin-openapi/routers"
@@ -49,6 +50,7 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 	if err != nil {
 		panic(err)
 	}
+	swagger.Paths = SwaggerPathsToGorillaPaths(swagger.Paths)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -68,6 +70,14 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 		})
 	}
 
+}
+
+func SwaggerPathsToGorillaPaths(paths openapi3.Paths) openapi3.Paths {
+	newPaths := openapi3.Paths{}
+	for path, pathItem := range paths {
+		newPaths[codegen.SwaggerUriToGorillaUri(path)] = pathItem
+	}
+	return newPaths
 }
 
 // This function is called from the middleware above and actually does the work

--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -104,7 +104,7 @@ func validateRequest(r *http.Request, router routers.Router, options *Options) (
 
 	if err := openapi3filter.ValidateRequest(context.Background(), requestValidationInput); err != nil {
 		me := openapi3.MultiError{}
-		if errors.As(err, &me) {
+		if errors.As(err, &me) && options.Options.MultiError {
 			errFunc := getMultiErrorHandlerFromOptions(options)
 			return errFunc(me)
 		}
@@ -112,6 +112,8 @@ func validateRequest(r *http.Request, router routers.Router, options *Options) (
 		switch e := err.(type) {
 		case *openapi3filter.RequestError:
 			// We've got a bad request
+			// Remove reference to schema
+			e.Reason = ""
 			// Split up the verbose error by lines and return the first one
 			// openapi errors seem to be multi-line with a decent message on the first
 			errorLines := strings.Split(e.Error(), "\n")

--- a/pkg/chi-middleware/test_spec.yaml
+++ b/pkg/chi-middleware/test_spec.yaml
@@ -95,6 +95,56 @@ paths:
                     type: string
                   id:
                     type: integer
+  /resource/{type}/{.id*}:
+    get:
+      operationId: getResource
+      parameters:
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                properties:
+                  name:
+                    type: string
+                  id:
+                    type: integer
+  /wildcardparam/{type}/{id=*}:
+    get:
+      operationId: getWildcardparamResource
+      parameters:
+        - name: type
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: id=*
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                properties:
+                  name:
+                    type: string
+                  id:
+                    type: integer
 components:
   securitySchemes:
     BearerAuth:

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -40,8 +40,8 @@ type pathParam struct {
 }
 
 func init() {
-	pathParamRE = regexp.MustCompile(`{[.;?]?([^{}*]+)\*?}`)
-	wildcardOnlyPathParamRE = regexp.MustCompile(`{[.;?]?([^{}]+)(=?\*)}`)
+	pathParamRE = regexp.MustCompile(`{[.;?]?([^{}=*]+)(=?\*)?}`)
+	wildcardOnlyPathParamRE = regexp.MustCompile(`{[.;?]?([^{}=*]+)(=\*)}`)
 
 	predeclaredIdentifiers := []string{
 		// Types
@@ -433,9 +433,10 @@ func SwaggerUriToFiberUri(uri string) string {
 //	{?param}
 //	{?param*}
 func SwaggerUriToChiUri(uri string) string {
-	i := wildcardOnlyPathParamRE.FindAllStringIndex(uri, -1)
-	if len(i) > 1 {
-		panic("chi does not support multiple wildcards in a single path")
+	// Wildcard must be the last pattern
+	i := wildcardOnlyPathParamRE.FindStringIndex(uri)
+	if i != nil && i[1] != len(uri) {
+		panic("chi: wildcard '{param=*}' must be the last pattern")
 	}
 
 	return pathParamRE.ReplaceAllString(wildcardOnlyPathParamRE.ReplaceAllString(uri, "*"), "{$1}")
@@ -470,9 +471,10 @@ func SwaggerUriToGinUri(uri string) string {
 //	{?param}
 //	{?param*}
 func SwaggerUriToGorillaUri(uri string) string {
-	i := wildcardOnlyPathParamRE.FindAllStringIndex(uri, -1)
-	if len(i) > 1 {
-		panic("Gorilla does not support multiple wildcards in a single path")
+	// Wildcard must be the last pattern
+	i := wildcardOnlyPathParamRE.FindStringIndex(uri)
+	if i != nil && i[1] != len(uri) {
+		panic("gorilla: wildcard '{param=*}' must be the last pattern")
 	}
 	return pathParamRE.ReplaceAllString(wildcardOnlyPathParamRE.ReplaceAllString(uri, "{$1$2:.*}"), "{$1}")
 }

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -474,7 +474,7 @@ func SwaggerUriToGorillaUri(uri string) string {
 	if len(i) > 1 {
 		panic("Gorilla does not support multiple wildcards in a single path")
 	}
-	return pathParamRE.ReplaceAllString(wildcardOnlyPathParamRE.ReplaceAllString(uri, "$1$2:.*"), "{$1}")
+	return pathParamRE.ReplaceAllString(wildcardOnlyPathParamRE.ReplaceAllString(uri, "{$1$2:.*}"), "{$1}")
 }
 
 // OrderedParamsFromUri returns the argument names, in order, in a given URI string, so for

--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -40,8 +40,8 @@ type pathParam struct {
 }
 
 func init() {
-	pathParamRE = regexp.MustCompile(`{[.;?]?([^{}=*]+)(=?\*)?}`)
-	wildcardOnlyPathParamRE = regexp.MustCompile(`{[.;?]?([^{}=*]+)(=?\*)}`)
+	pathParamRE = regexp.MustCompile(`{[.;?]?([^{}*]+)\*?}`)
+	wildcardOnlyPathParamRE = regexp.MustCompile(`{[.;?]?([^{}]+)(=?\*)}`)
 
 	predeclaredIdentifiers := []string{
 		// Types
@@ -470,7 +470,11 @@ func SwaggerUriToGinUri(uri string) string {
 //	{?param}
 //	{?param*}
 func SwaggerUriToGorillaUri(uri string) string {
-	return pathParamRE.ReplaceAllString(uri, "{$1}")
+	i := wildcardOnlyPathParamRE.FindAllStringIndex(uri, -1)
+	if len(i) > 1 {
+		panic("Gorilla does not support multiple wildcards in a single path")
+	}
+	return pathParamRE.ReplaceAllString(wildcardOnlyPathParamRE.ReplaceAllString(uri, "$1$2:.*"), "{$1}")
 }
 
 // OrderedParamsFromUri returns the argument names, in order, in a given URI string, so for

--- a/pkg/codegen/utils_test.go
+++ b/pkg/codegen/utils_test.go
@@ -263,6 +263,28 @@ func TestSwaggerUriToGinUri(t *testing.T) {
 	assert.Equal(t, "/path/:arg/foo", SwaggerUriToGinUri("/path/{?arg*}/foo"))
 }
 
+func TestSwaggerUriToChiUri(t *testing.T) {
+	assert.Equal(t, "/path", SwaggerUriToChiUri("/path"))
+	assert.Equal(t, "/path/{arg}", SwaggerUriToChiUri("/path/{arg}"))
+	assert.Equal(t, "/path/{arg1}/{arg2}", SwaggerUriToChiUri("/path/{arg1}/{arg2}"))
+	assert.Equal(t, "/path/{arg1}/{arg2}/foo", SwaggerUriToChiUri("/path/{arg1}/{arg2}/foo"))
+
+	// Make sure all the exploded and alternate formats match too
+	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToChiUri("/path/{arg}/foo"))
+	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToChiUri("/path/{arg*}/foo"))
+	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToChiUri("/path/{.arg}/foo"))
+	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToChiUri("/path/{.arg*}/foo"))
+	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToChiUri("/path/{;arg}/foo"))
+	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToChiUri("/path/{;arg*}/foo"))
+	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToChiUri("/path/{?arg}/foo"))
+	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToChiUri("/path/{?arg*}/foo"))
+
+	// Wildcard param
+	assert.Equal(t, "/path/*", SwaggerUriToChiUri("/path/{arg1=*}"))
+	assert.Equal(t, "/path/{arg1}/*", SwaggerUriToChiUri("/path/{arg1}/{arg2=*}"))
+	assert.Panics(t, func() { SwaggerUriToChiUri("/path/{arg1=*}/{arg2=*}") }, "chi: wildcard '{param=*}' must be the last pattern")
+}
+
 func TestSwaggerUriToGorillaUri(t *testing.T) { // TODO
 	assert.Equal(t, "/path", SwaggerUriToGorillaUri("/path"))
 	assert.Equal(t, "/path/{arg}", SwaggerUriToGorillaUri("/path/{arg}"))
@@ -278,6 +300,13 @@ func TestSwaggerUriToGorillaUri(t *testing.T) { // TODO
 	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToGorillaUri("/path/{;arg*}/foo"))
 	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToGorillaUri("/path/{?arg}/foo"))
 	assert.Equal(t, "/path/{arg}/foo", SwaggerUriToGorillaUri("/path/{?arg*}/foo"))
+
+	// Wildcard param
+	assert.Equal(t, "/path/{arg=*:.*}", SwaggerUriToGorillaUri("/path/{arg=*}"))
+	assert.Equal(t, "/path/{arg=*:.*}", SwaggerUriToGorillaUri("/path/{.arg=*}"))
+	assert.Equal(t, "/path/{arg1}/{arg2=*:.*}", SwaggerUriToGorillaUri("/path/{arg1}/{arg2=*}"))
+	assert.Panics(t, func() { SwaggerUriToGorillaUri("/path/{arg1=*}/{arg2=*}") }, "gorilla: wildcard '{param=*}' must be the last pattern")
+
 }
 
 func TestOrderedParamsFromUri(t *testing.T) {


### PR DESCRIPTION
This Pr implements SwaggerPathsToGorillaPaths method which allow to convert Paths with wildcard to Gorilla compatible Paths.

Example:
`/v1/resources/{type}/{id}/{nestedContainsPath=*}` to `/v1/resources/{type}/{id}/{nestedContainsPath=*:.*}`


### TODO
- [x] Add unit and integration tests