### PR TITLE
feat: [ENG-490] BindQueryParameter to handle split params in separated params

### DIFF
--- a/pkg/runtime/bindparam.go
+++ b/pkg/runtime/bindparam.go
@@ -349,14 +349,11 @@ func BindQueryParameter(style string, explode bool, required bool, paramName str
 
 				// Handle param values with multiple values split by comma.
 				// Basically be able to handle: ?includes=employs,association&includes=worksAt
-				splitValues := lo.Map(values, func(value string, _ int) []string {
+				splitValues := lo.FlatMap(values, func(value string, _ int) []string {
 					return strings.Split(value, ",")
 				})
-				reducedValues := lo.Reduce(splitValues, func(agg []string, item []string, _ int) []string {
-					return append(agg, item...)
-				}, []string{})
 
-				err = bindSplitPartsToDestinationArray(reducedValues, output)
+				err = bindSplitPartsToDestinationArray(splitValues, output)
 			case reflect.Struct:
 				// This case is really annoying, and error prone, but the
 				// form style object binding doesn't tell us which arguments

--- a/pkg/runtime/bindparam_test.go
+++ b/pkg/runtime/bindparam_test.go
@@ -333,6 +333,16 @@ func TestBindQueryParameter(t *testing.T) {
 		err := BindQueryParameter("form", true, false, "birthday", queryParams, &birthday)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, birthday)
+
+		// Explode array params with not exploded values
+		expectedInclude := []string{"employs", "worksAt", "belongsTo"}
+		var include *[]string
+		queryParams = url.Values{
+			"include": {"employs", "worksAt,belongsTo"},
+		}
+		err = BindQueryParameter("form", true, false, "include", queryParams, &include)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedInclude, *include)
 	})
 
 	t.Run("optional", func(t *testing.T) {


### PR DESCRIPTION
This pr adds in `BindQueryParameter` a method to split values using comma.
This allows to handle both explode `?includes=employs&includes=association` and not explode `?includes=employs,association` when using` explode=true`.

Side effects it allow this too: `?includes=employs,works&includes=association`