### PR TITLE
fix: [ENG-823] Removes verbose error messages

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,3 @@
+# Enable/disable creation of status checks
+enabled: true
+titleOnly: true

--- a/pkg/codegen/templates/chi/chi-middleware.tmpl
+++ b/pkg/codegen/templates/chi/chi-middleware.tmpl
@@ -210,7 +210,7 @@ type UnmarshallingParamError struct {
 }
 
 func (e *UnmarshallingParamError) Error() string {
-    return fmt.Sprintf("Error unmarshalling parameter %s as JSON: %s", e.ParamName, e.Err.Error())
+    return fmt.Sprintf("Error unmarshalling parameter '%s' as JSON", e.ParamName)
 }
 
 func (e *UnmarshallingParamError) Unwrap() error {
@@ -244,7 +244,7 @@ type InvalidParamFormatError struct {
 }
 
 func (e *InvalidParamFormatError) Error() string {
-    return fmt.Sprintf("Invalid format for parameter %s: %s", e.ParamName, e.Err.Error())
+    return fmt.Sprintf("Invalid format for parameter '%s'", e.ParamName)
 }
 
 func (e *InvalidParamFormatError) Unwrap() error {

--- a/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
+++ b/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
@@ -210,7 +210,7 @@ type UnmarshallingParamError struct {
 }
 
 func (e *UnmarshallingParamError) Error() string {
-    return fmt.Sprintf("Error unmarshalling parameter %s as JSON: %s", e.ParamName, e.Err.Error())
+    return fmt.Sprintf("Error unmarshalling parameter '%s' as JSON", e.ParamName)
 }
 
 func (e *UnmarshallingParamError) Unwrap() error {
@@ -244,7 +244,7 @@ type InvalidParamFormatError struct {
 }
 
 func (e *InvalidParamFormatError) Error() string {
-    return fmt.Sprintf("Invalid format for parameter %s: %s", e.ParamName, e.Err.Error())
+    return fmt.Sprintf("Invalid format for parameter '%s'", e.ParamName)
 }
 
 func (e *InvalidParamFormatError) Unwrap() error {


### PR DESCRIPTION
Simple fix. This removes the verbose error messages for invalid params. Addresses a security concern.

Once this is merged, we'll need to regenerate the servers on `atlas`