### PR TITLE
fix: [ENG-1396] decode raw path to support encoded path variables 

### DIFF
--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/clinia/oapi-codegen/pkg/codegen"
@@ -55,6 +56,9 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Decode the path to support encoded path variables
+			// This is a hack to avoid modifying the openapi3filter dependency
+			r.URL.RawPath, _ = url.QueryUnescape(r.URL.RawPath)
 
 			// validate request
 			if statusCode, err := validateRequest(r, router, options); err != nil {

--- a/pkg/chi-middleware/oapi_validate.go
+++ b/pkg/chi-middleware/oapi_validate.go
@@ -58,6 +58,7 @@ func OapiRequestValidatorWithOptions(swagger *openapi3.T, options *Options) func
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Decode the path to support encoded path variables
 			// This is a hack to avoid modifying the openapi3filter dependency
+			// Reference: [ENG-1396]
 			r.URL.RawPath, _ = url.QueryUnescape(r.URL.RawPath)
 
 			// validate request

--- a/pkg/chi-middleware/oapi_validate_test.go
+++ b/pkg/chi-middleware/oapi_validate_test.go
@@ -19,6 +19,8 @@ package middleware
 // 	"github.com/stretchr/testify/require"
 // )
 
+// TODO ENG-1396 Add test for encoded URL
+
 // //go:embed test_spec.yaml
 // var testSchema []byte
 


### PR DESCRIPTION
- Hackish fix to decode the url before it is sent to the validator (kin-openapi openapi3filter)
- A better solution would be to modify the decoder in the kin-openapi openapi3filter dependency